### PR TITLE
feature: parse coder response as XML markup instead of JSON

### DIFF
--- a/agent/llm.py
+++ b/agent/llm.py
@@ -284,7 +284,8 @@ _CHANGE_RE = re.compile(
     r"<change\b(?P<attrs>[^>]*)>(?P<body>.*?)</change>",
     re.DOTALL,
 )
-_CONTENT_RE = re.compile(r"<content>\n?(?P<content>.*?)\n?</content>", re.DOTALL)
+
+_CONTENT_RE = re.compile(r"<content>\n(?P<content>.*?\n)</content>", re.DOTALL)
 _ATTR_RE = re.compile(r'(?P<name>[a-zA-Z_][\w-]*)="(?P<value>[^"]*)"')
 
 

--- a/agent/llm.py
+++ b/agent/llm.py
@@ -1,5 +1,7 @@
 import asyncio
+import html
 from collections.abc import Callable
+import re
 from typing import TypeVar
 
 from pydantic import (
@@ -74,19 +76,20 @@ task from that plan. Your job is to produce exact file replacements only for
 that task.
 
 RULES:
-1. Return ONLY a valid JSON object - no markdown, no explanation, no backticks.
-2. The JSON must follow this exact schema:
-   {
-     "summary": "One sentence describing what you did.",
-     "changes": [
-       {
-         "path": "relative/path/to/file.py",
-         "action": "update" | "create" | "delete" | "mkdir" | "copy" | "move",
-         "content": "full new file content as a string (create/update only)",
-         "src": "source path (copy/move only)"
-       }
-     ]
-   }
+1. Return ONLY the tagged response format shown below - no markdown fences, no
+   JSON, no explanation outside the tags.
+2. The response must follow this exact structure:
+   <code_response>
+   <summary>One sentence describing what you did.</summary>
+   <changes>
+   <change action="update" path="relative/path/to/file.py">
+   <content>
+   full new file content for create/update actions only
+   </content>
+   </change>
+   <change action="copy" path="relative/path/to/new.py" src="relative/path/to/source.py"></change>
+   </changes>
+   </code_response>
 3. Action rules:
    - create/update: always provide COMPLETE file content in "content". No "src".
      The "create" action automatically creates any missing parent directories;
@@ -180,7 +183,7 @@ async def _call_structured_llm(
     generation = ChatGenerationSettings(
         max_tokens=config.max_response_tokens,
         temperature=config.structured_llm_temperature,
-        response_format="json_object",
+        response_format="json_object" if parser is not parse_code_response_markup else None,
     )
     retryable_attempts = config.structured_llm_retries
     messages = base_messages
@@ -201,7 +204,7 @@ async def _call_structured_llm(
         except EmptyLLMResponseError:
             if attempt >= retryable_attempts:
                 raise
-        except ValidationError as exc:
+        except (ValidationError, ValueError) as exc:
             if attempt >= retryable_attempts:
                 raise ValueError(
                     f"Invalid structured response from model: {exc}"
@@ -210,7 +213,11 @@ async def _call_structured_llm(
                 base_messages[0],
                 ChatMessage(
                     role="user",
-                    content=_build_structured_llm_retry_message(user_message, exc),
+                    content=_build_structured_llm_retry_message(
+                        user_message,
+                        exc,
+                        parser=parser,
+                    ),
                 ),
             )
         except ProviderError as exc:
@@ -255,13 +262,66 @@ async def _get_structured_llm_content(
 
 def _build_structured_llm_retry_message(
     user_message: str,
-    exc: ValidationError,
+    exc: Exception,
+    *,
+    parser: Callable[[str], BaseModel],
 ) -> str:
+    format_instruction = (
+        "Return ONLY a valid JSON object that matches the schema."
+        if parser is not parse_code_response_markup
+        else "Return ONLY the tagged <code_response> format that matches the schema."
+    )
     return (
         f"{user_message}\n\n"
-        "Your previous response was not valid JSON.\n"
+        "Your previous response did not match the required structured format.\n"
         f"Parser error: {exc}\n"
-        "Return ONLY a valid JSON object that matches the schema."
+        f"{format_instruction}"
+    )
+
+
+_SUMMARY_RE = re.compile(r"<summary>(?P<summary>.*?)</summary>", re.DOTALL)
+_CHANGE_RE = re.compile(
+    r"<change\b(?P<attrs>[^>]*)>(?P<body>.*?)</change>",
+    re.DOTALL,
+)
+_CONTENT_RE = re.compile(r"<content>\n?(?P<content>.*?)\n?</content>", re.DOTALL)
+_ATTR_RE = re.compile(r'(?P<name>[a-zA-Z_][\w-]*)="(?P<value>[^"]*)"')
+
+
+def parse_code_response_markup(content: str) -> CodeResponseSchema:
+    """Parse the coder's tagged response into the existing validated schema."""
+    summary_match = _SUMMARY_RE.search(content)
+    if summary_match is None:
+        raise ValueError("Missing <summary>...</summary> block.")
+
+    changes: list[CodeChangeSchema] = []
+    for change_match in _CHANGE_RE.finditer(content):
+        attrs = {
+            match.group("name"): match.group("value")
+            for match in _ATTR_RE.finditer(change_match.group("attrs"))
+        }
+        action = attrs.get("action")
+        path = attrs.get("path")
+        if action is None or path is None:
+            raise ValueError("Each <change> must include action and path attributes.")
+
+        change_data: dict[str, str] = {"action": action, "path": path}
+        if src := attrs.get("src"):
+            change_data["src"] = src
+
+        content_match = _CONTENT_RE.search(change_match.group("body"))
+        if content_match is not None:
+            change_data["content"] = content_match.group("content")
+
+        # content_match = _CONTENT_RE.search(change_match.group("body"))
+        # if content_match is not None:
+        #     change_data["content"] = html.unescape(content_match.group("content"))
+
+        changes.append(CodeChangeSchema.model_validate(change_data))
+
+    return CodeResponseSchema(
+        summary=summary_match.group("summary").strip(),
+        changes=changes,
     )
 
 
@@ -317,7 +377,7 @@ async def call_coder_for_task(
         system_prompt=CODER_SYSTEM_PROMPT,
         user_message=user_message,
         config=config,
-        parser=CodeResponseSchema.model_validate_json,
+        parser=parse_code_response_markup,
         chat_adapter=chat_adapter,
         on_chunk=on_chunk,
     )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -32,6 +32,20 @@ from workflow.editing import open_plan_in_editor
 from workflow.execution import build_working_context, validate_llm_result
 
 
+def coder_markup_response(
+    summary: str = "Recovered",
+    changes: str = "",
+) -> str:
+    return (
+        "<code_response>\n"
+        f"<summary>{summary}</summary>\n"
+        "<changes>\n"
+        f"{changes}"
+        "</changes>\n"
+        "</code_response>"
+    )
+
+
 def test_config_rejects_impossible_context_budget() -> None:
     try:
         Config(max_context_tokens=1024, max_response_tokens=1024)
@@ -489,7 +503,7 @@ def test_call_coder_rejects_multi_task_plans() -> None:
         asyncio.run(call_coder(plan, "<codebase />", Config()))
 
 
-def test_call_coder_retries_invalid_json_response(monkeypatch) -> None:
+def test_call_coder_retries_invalid_structured_response(monkeypatch) -> None:
     plan = PlanSchema(
         summary="Recover from malformed JSON",
         tasks=[
@@ -503,7 +517,7 @@ def test_call_coder_retries_invalid_json_response(monkeypatch) -> None:
     responses = iter(
         [
             "not-json",
-            CodeResponseSchema(summary="Recovered", changes=[]).model_dump_json(),
+            coder_markup_response(),
         ]
     )
     seen_messages: list[tuple[str, ...]] = []
@@ -525,7 +539,53 @@ def test_call_coder_retries_invalid_json_response(monkeypatch) -> None:
     assert result.summary == "Recovered"
     assert len(seen_messages) == 2
     assert seen_messages[1][1].startswith("<codebase />\n\n<approved_plan_summary>")
-    assert "not valid JSON" in seen_messages[1][1]
+    assert "required structured format" in seen_messages[1][1]
+    assert "<code_response>" in seen_messages[1][1]
+
+
+def test_call_coder_parses_raw_file_content_without_json_escaping(monkeypatch) -> None:
+    plan = PlanSchema(
+        summary="Recover from malformed JSON",
+        tasks=[
+            PlanTaskSchema(
+                files=["src/app.py"],
+                goal="Update the CLI entry point",
+                reasoning="The entry point needs the first change.",
+            )
+        ],
+    )
+    raw_content = 'print("hello")\nhtml = "<main>ok</main>"\n'
+    response = coder_markup_response(
+        summary="Updated app",
+        changes=(
+            '<change action="update" path="src/app.py">\n'
+            "<content>\n"
+            f"{raw_content}"
+            "</content>\n"
+            "</change>\n"
+        ),
+    )
+    generations: list[ChatGenerationSettings | None] = []
+
+    async def fake_run_chat(messages, config, adapter=None, generation=None):
+        generations.append(generation)
+        return SimpleNamespace(content=response)
+
+    monkeypatch.setattr("agent.llm.run_chat", fake_run_chat)
+
+    result = asyncio.run(
+        call_coder(
+            plan,
+            "<codebase />",
+            Config(chat_streaming=False),
+        )
+    )
+
+    assert result.summary == "Updated app"
+    assert result.changes[0].path == "src/app.py"
+    assert result.changes[0].content == raw_content
+    assert generations[0] is not None
+    assert generations[0].response_format is None
 
 
 def test_call_coder_retries_empty_response(monkeypatch) -> None:
@@ -542,7 +602,7 @@ def test_call_coder_retries_empty_response(monkeypatch) -> None:
     responses = iter(
         [
             "",
-            CodeResponseSchema(summary="Recovered", changes=[]).model_dump_json(),
+            coder_markup_response(),
         ]
     )
 
@@ -577,10 +637,7 @@ def test_call_coder_retries_transient_provider_error(monkeypatch) -> None:
         [
             ProviderUnavailableError("openai", "temporary outage"),
             SimpleNamespace(
-                content=CodeResponseSchema(
-                    summary="Recovered",
-                    changes=[],
-                ).model_dump_json()
+                content=coder_markup_response()
             ),
         ]
     )
@@ -624,10 +681,7 @@ def test_call_coder_retries_rate_limit_with_backoff(monkeypatch) -> None:
         [
             ProviderRateLimitError("openai", "too many requests"),
             SimpleNamespace(
-                content=CodeResponseSchema(
-                    summary="Recovered",
-                    changes=[],
-                ).model_dump_json()
+                content=coder_markup_response()
             ),
         ]
     )
@@ -673,7 +727,7 @@ def test_call_coder_streams_with_injected_adapter(monkeypatch) -> None:
 
     async def fake_stream_chat(messages, config, adapter=None, generation=None):
         seen_adapters.append(adapter)
-        yield SimpleNamespace(content='{"summary":"ok","changes":[]}')  # type: ignore[misc]
+        yield SimpleNamespace(content=coder_markup_response(summary="ok"))  # type: ignore[misc]
 
     monkeypatch.setattr("agent.llm.stream_chat", fake_stream_chat)
 
@@ -728,7 +782,7 @@ def test_call_coder_streams_with_injected_adapter(monkeypatch) -> None:
 
     assert result.summary == "ok"
     assert seen_adapters == [adapter]
-    assert chunks == ['{"summary":"ok","changes":[]}']
+    assert chunks == [coder_markup_response(summary="ok")]
 
 
 def test_handle_task_failure_returns_next_state() -> None:


### PR DESCRIPTION
Gemma 4 works well for the current version, but qwen3.6 returns error:

`"{"timestamp": "2026-06-11T17:33:58.296386+00:00", "level": "error", "event": "run.failed", "state": "executing", "message": "Invalid structured response from model: 1 validation error for CodeResponseSchema\n  Invalid JSON: control character (\\u0000-\\u001F) found while parsing a string at line 8 column 0 [type=json_invalid, input_value='{\\n  \"summary\": \"Created...</html>\"\\n    }\\n  ]\\n}', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.13/v/json_invalid", "payload": {}}"`

One of the solution is to move towards XML markup.